### PR TITLE
Fix clang-format violations in src files

### DIFF
--- a/src/FileHelper.cpp
+++ b/src/FileHelper.cpp
@@ -8,12 +8,13 @@
 #include <QStandardPaths>
 #include <QDateTime>
 
-namespace wekde {
+namespace wekde
+{
 
-FileHelper::FileHelper(QObject* parent) : QObject(parent) {
+FileHelper::FileHelper(QObject* parent): QObject(parent) {
     // Ensure config directory exists
     QDir dir(wallpaperConfigDir());
-    if (!dir.exists()) {
+    if (! dir.exists()) {
         dir.mkpath(".");
     }
 }
@@ -25,9 +26,7 @@ QString FileHelper::configDir() const {
     return xdgConfig + "/wekde";
 }
 
-QString FileHelper::wallpaperConfigDir() const {
-    return configDir() + "/wallpaper";
-}
+QString FileHelper::wallpaperConfigDir() const { return configDir() + "/wallpaper"; }
 
 QString FileHelper::wallpaperConfigFile(const QString& id) const {
     return wallpaperConfigDir() + "/" + id + ".json";
@@ -35,7 +34,7 @@ QString FileHelper::wallpaperConfigFile(const QString& id) const {
 
 QByteArray FileHelper::readFile(const QString& path) {
     QFile file(path);
-    if (!file.open(QIODevice::ReadOnly)) {
+    if (! file.open(QIODevice::ReadOnly)) {
         qWarning() << "FileHelper: Cannot open file:" << path;
         return QByteArray();
     }
@@ -44,9 +43,9 @@ QByteArray FileHelper::readFile(const QString& path) {
 
 qint64 FileHelper::getDirSize(const QString& path, int depth) {
     qint64 totalSize = 0;
-    QDir dir(path);
+    QDir   dir(path);
 
-    if (!dir.exists()) {
+    if (! dir.exists()) {
         return 0;
     }
 
@@ -76,11 +75,12 @@ qint64 FileHelper::getDirSize(const QString& path, int depth) {
         }
 
         // Simpler approach: just iterate with depth limit
-        std::function<qint64(const QString&, int)> calcSize = [&](const QString& dirPath, int currentDepth) -> qint64 {
+        std::function<qint64(const QString&, int)> calcSize = [&](const QString& dirPath,
+                                                                  int currentDepth) -> qint64 {
             if (currentDepth > depth) return 0;
 
             qint64 size = 0;
-            QDir d(dirPath);
+            QDir   d(dirPath);
 
             for (const QFileInfo& info : d.entryInfoList(QDir::Files | QDir::NoDotAndDotDot)) {
                 size += info.size();
@@ -104,37 +104,37 @@ qint64 FileHelper::getDirSize(const QString& path, int depth) {
 QVariantMap FileHelper::getFolderList(const QString& path, const QVariantMap& opt) {
     QVariantMap result;
 
-    bool onlyDir = opt.value("only_dir", true).toBool();
+    bool        onlyDir   = opt.value("only_dir", true).toBool();
     QStringList fallbacks = opt.value("fallbacks", QStringList()).toStringList();
 
     // Find first existing directory
     QString folder = path;
-    QDir dir(folder);
+    QDir    dir(folder);
 
-    if (!dir.exists()) {
+    if (! dir.exists()) {
         for (const QString& fb : fallbacks) {
             QDir fbDir(fb);
             if (fbDir.exists()) {
                 folder = fb;
-                dir = fbDir;
+                dir    = fbDir;
                 break;
             }
         }
     }
 
-    if (!dir.exists()) {
+    if (! dir.exists()) {
         return QVariantMap(); // Return null/empty
     }
 
     result["folder"] = folder;
 
-    QVariantList items;
+    QVariantList  items;
     QDir::Filters filters = onlyDir ? QDir::Dirs : (QDir::Dirs | QDir::Files);
     filters |= QDir::NoDotAndDotDot;
 
     for (const QFileInfo& info : dir.entryInfoList(filters)) {
         QVariantMap item;
-        item["name"] = info.fileName();
+        item["name"]  = info.fileName();
         item["mtime"] = static_cast<qint64>(info.lastModified().toSecsSinceEpoch());
         items.append(item);
     }
@@ -145,19 +145,19 @@ QVariantMap FileHelper::getFolderList(const QString& path, const QVariantMap& op
 
 QVariantMap FileHelper::readWallpaperConfig(const QString& id) {
     QString filePath = wallpaperConfigFile(id);
-    QFile file(filePath);
+    QFile   file(filePath);
 
-    if (!file.exists()) {
+    if (! file.exists()) {
         return QVariantMap();
     }
 
-    if (!file.open(QIODevice::ReadOnly)) {
+    if (! file.open(QIODevice::ReadOnly)) {
         qWarning() << "FileHelper: Cannot read config:" << filePath;
         return QVariantMap();
     }
 
     QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
-    if (doc.isNull() || !doc.isObject()) {
+    if (doc.isNull() || ! doc.isObject()) {
         return QVariantMap();
     }
 
@@ -175,9 +175,9 @@ void FileHelper::writeWallpaperConfig(const QString& id, const QVariantMap& chan
 
     // Write back
     QString filePath = wallpaperConfigFile(id);
-    QFile file(filePath);
+    QFile   file(filePath);
 
-    if (!file.open(QIODevice::WriteOnly)) {
+    if (! file.open(QIODevice::WriteOnly)) {
         qWarning() << "FileHelper: Cannot write config:" << filePath;
         return;
     }

--- a/src/FileHelper.hpp
+++ b/src/FileHelper.hpp
@@ -5,7 +5,8 @@
 #include <QVariantMap>
 #include <QVariantList>
 
-namespace wekde {
+namespace wekde
+{
 
 class FileHelper : public QObject {
     Q_OBJECT
@@ -15,14 +16,14 @@ public:
     virtual ~FileHelper();
 
     // File operations
-    Q_INVOKABLE QByteArray readFile(const QString& path);
-    Q_INVOKABLE qint64 getDirSize(const QString& path, int depth = 3);
+    Q_INVOKABLE QByteArray  readFile(const QString& path);
+    Q_INVOKABLE qint64      getDirSize(const QString& path, int depth = 3);
     Q_INVOKABLE QVariantMap getFolderList(const QString& path, const QVariantMap& opt = {});
 
     // Wallpaper config operations
     Q_INVOKABLE QVariantMap readWallpaperConfig(const QString& id);
-    Q_INVOKABLE void writeWallpaperConfig(const QString& id, const QVariantMap& changed);
-    Q_INVOKABLE void resetWallpaperConfig(const QString& id);
+    Q_INVOKABLE void        writeWallpaperConfig(const QString& id, const QVariantMap& changed);
+    Q_INVOKABLE void        resetWallpaperConfig(const QString& id);
 
 private:
     QString configDir() const;

--- a/src/MouseGrabber.cpp
+++ b/src/MouseGrabber.cpp
@@ -67,7 +67,7 @@ void MouseGrabber::sendMouseEvent(QMouseEvent* event) {
 void MouseGrabber::sendHoverEvent(QHoverEvent* event) {
     if (m_target) {
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-        auto newPos = mapToItem(m_target, event->position());
+        auto        newPos = mapToItem(m_target, event->position());
         QHoverEvent temp(event->type(),
                          newPos,
                          event->globalPosition(),

--- a/src/MouseGrabber.hpp
+++ b/src/MouseGrabber.hpp
@@ -8,40 +8,39 @@
 namespace wekde
 {
 
-class MouseGrabber : public QQuickItem
-{
+class MouseGrabber : public QQuickItem {
     Q_OBJECT
-	Q_PROPERTY(bool forceCapture READ forceCapture WRITE setForceCapture NOTIFY forceCaptureChanged)
-	Q_PROPERTY(QQuickItem* target READ target WRITE setTarget NOTIFY targetChanged)
+    Q_PROPERTY(bool forceCapture READ forceCapture WRITE setForceCapture NOTIFY forceCaptureChanged)
+    Q_PROPERTY(QQuickItem* target READ target WRITE setTarget NOTIFY targetChanged)
 
 public:
-	MouseGrabber(QQuickItem *parent = nullptr);
-	virtual ~MouseGrabber() override {};
+    MouseGrabber(QQuickItem* parent = nullptr);
+    virtual ~MouseGrabber() override {};
 
-	bool forceCapture() const;
-	QQuickItem* target() const; 
+    bool        forceCapture() const;
+    QQuickItem* target() const;
 
-	void setForceCapture(bool);
-	void setTarget(QQuickItem*);
+    void setForceCapture(bool);
+    void setTarget(QQuickItem*);
 
-	Q_INVOKABLE void sendEvent(QObject*, QEvent*);
+    Q_INVOKABLE void sendEvent(QObject*, QEvent*);
 
 protected:
-	void mouseUngrabEvent() override;
-	void mousePressEvent(QMouseEvent*) override;
-	void mouseMoveEvent(QMouseEvent*) override;
-	void mouseReleaseEvent(QMouseEvent *) override;
-	void mouseDoubleClickEvent(QMouseEvent *) override;
-	void hoverMoveEvent(QHoverEvent *) override;
+    void mouseUngrabEvent() override;
+    void mousePressEvent(QMouseEvent*) override;
+    void mouseMoveEvent(QMouseEvent*) override;
+    void mouseReleaseEvent(QMouseEvent*) override;
+    void mouseDoubleClickEvent(QMouseEvent*) override;
+    void hoverMoveEvent(QHoverEvent*) override;
 
 signals:
-	void forceCaptureChanged();
-	void targetChanged();
+    void forceCaptureChanged();
+    void targetChanged();
 
 private:
-    void sendMouseEvent(QMouseEvent*);
-    void sendHoverEvent(QHoverEvent*);
-	bool m_forceCapture {false};
-    QPointer<QQuickItem> m_target {nullptr};
+    void                 sendMouseEvent(QMouseEvent*);
+    void                 sendHoverEvent(QHoverEvent*);
+    bool                 m_forceCapture { false };
+    QPointer<QQuickItem> m_target { nullptr };
 };
-}
+} // namespace wekde

--- a/src/TTYSwitchMonitor.cpp
+++ b/src/TTYSwitchMonitor.cpp
@@ -3,24 +3,21 @@
 
 using namespace wekde;
 
-TTYSwitchMonitor::TTYSwitchMonitor(QQuickItem *parent)
-    : QQuickItem(parent), m_sleeping(false) {
+TTYSwitchMonitor::TTYSwitchMonitor(QQuickItem* parent): QQuickItem(parent), m_sleeping(false) {
     QDBusConnection systemBus = QDBusConnection::systemBus();
-    if (!systemBus.isConnected()) {
+    if (! systemBus.isConnected()) {
         qFatal("Cannot connect to the D-Bus system bus");
         return;
     }
 
-    bool connected = systemBus.connect(
-        "org.freedesktop.login1",
-        "/org/freedesktop/login1",
-        "org.freedesktop.login1.Manager",
-        "PrepareForSleep",
-        this,
-        SLOT(handlePrepareForSleep(bool))
-    );
+    bool connected = systemBus.connect("org.freedesktop.login1",
+                                       "/org/freedesktop/login1",
+                                       "org.freedesktop.login1.Manager",
+                                       "PrepareForSleep",
+                                       this,
+                                       SLOT(handlePrepareForSleep(bool)));
 
-    if (!connected) {
+    if (! connected) {
         qFatal("Failed to connect to PrepareForSleep signal");
     }
 }

--- a/src/TTYSwitchMonitor.hpp
+++ b/src/TTYSwitchMonitor.hpp
@@ -2,14 +2,15 @@
 #include <QQuickItem>
 #include <QDBusConnection>
 
-namespace wekde {
+namespace wekde
+{
 
 class TTYSwitchMonitor : public QQuickItem {
     Q_OBJECT
     Q_PROPERTY(bool sleeping READ isSleeping NOTIFY ttySwitch)
 
 public:
-    TTYSwitchMonitor(QQuickItem *parent = nullptr);
+    TTYSwitchMonitor(QQuickItem* parent = nullptr);
 
     bool isSleeping() const { return m_sleeping; }
 
@@ -23,4 +24,4 @@ private:
     bool m_sleeping;
 };
 
-}
+} // namespace wekde

--- a/src/backend_mpv/MpvBackend.cpp
+++ b/src/backend_mpv/MpvBackend.cpp
@@ -8,20 +8,20 @@
 #include <QtGui/QGuiApplication>
 #include <QtGui/QOpenGLContext>
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-#include <QtOpenGL/QOpenGLFramebufferObject>
+#    include <QtOpenGL/QOpenGLFramebufferObject>
 #else
-#include <QtGui/QOpenGLFramebufferObject>
+#    include <QtGui/QOpenGLFramebufferObject>
 #endif
 #include <QtGui/QOpenGLFunctions>
 #include <QtQuick/QQuickWindow>
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-#include <QtQuick/QQuickOpenGLUtils>
+#    include <QtQuick/QQuickOpenGLUtils>
 #endif
 
 #include <QtGui/QOffscreenSurface>
 #include <QtQuick/QSGSimpleTextureNode>
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-#include <QSGTexture>
+#    include <QSGTexture>
 #endif
 
 #include <clocale>
@@ -32,14 +32,14 @@
 #include <sys/stat.h>
 
 #if defined(__linux__) || defined(__FreeBSD__)
-//#ifdef ENABLE_X11
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-#    include <QX11Info> // IWYU pragma: keep
-#elif (QT_VERSION < QT_VERSION_CHECK(6, 5, 0))
+// #ifdef ENABLE_X11
+#    if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+#        include <QX11Info> // IWYU pragma: keep
+#    elif (QT_VERSION < QT_VERSION_CHECK(6, 5, 0))
 // Qt 6.0-6.4: use platformNativeInterface for X11 (6.0-6.1) and Wayland (6.0-6.4)
-#    include <qpa/qplatformnativeinterface.h>
-#endif
-//#endif
+#        include <qpa/qplatformnativeinterface.h>
+#    endif
+// #endif
 #endif
 
 Q_LOGGING_CATEGORY(wekdeMpv, "wekde.mpv")
@@ -82,27 +82,27 @@ int CreateMpvContex(mpv_handle* mpv, mpv_render_context** mpv_gl) {
 #if defined(__linux__) || defined(__FreeBSD__)
     if (QGuiApplication::platformName().contains("xcb")) {
         params[2].type = MPV_RENDER_PARAM_X11_DISPLAY;
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 2, 0))
+#    if (QT_VERSION >= QT_VERSION_CHECK(6, 2, 0))
         if (auto* x11App = qGuiApp->nativeInterface<QNativeInterface::QX11Application>()) {
             params[2].data = x11App->display();
         }
-#elif (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#    elif (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
         auto* native   = QGuiApplication::platformNativeInterface();
         params[2].data = native->nativeResourceForWindow("display", nullptr);
-#else
+#    else
         params[2].data = QX11Info::display();
-#endif
+#    endif
     }
     if (QGuiApplication::platformName().contains("wayland")) {
         params[2].type = MPV_RENDER_PARAM_WL_DISPLAY;
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
+#    if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
         if (auto* waylandApp = qGuiApp->nativeInterface<QNativeInterface::QWaylandApplication>()) {
             params[2].data = waylandApp->display();
         }
-#else
+#    else
         auto* native   = QGuiApplication::platformNativeInterface();
         params[2].data = native->nativeResourceForWindow("display", nullptr);
-#endif
+#    endif
     }
 #endif
     int code = mpv_render_context_create(mpv_gl, mpv, params);

--- a/src/backend_mpv/qthelper.hpp
+++ b/src/backend_mpv/qthelper.hpp
@@ -12,18 +12,20 @@
 #include <QSharedPointer>
 #include <QMetaType>
 
-namespace mpv {
-namespace qt {
+namespace mpv
+{
+namespace qt
+{
 
 // Wrapper around mpv_handle. Does refcounting under the hood.
-class Handle
-{
+class Handle {
     struct container {
-        explicit container(mpv_handle *h) : mpv(h) {}
+        explicit container(mpv_handle* h): mpv(h) {}
         ~container() { mpv_terminate_destroy(mpv); }
-        mpv_handle *mpv;
+        mpv_handle* mpv;
     };
     QSharedPointer<container> sptr;
+
 public:
     // Construct a new Handle from a raw mpv_handle with refcount 1. If the
     // last Handle goes out of scope, the mpv_handle will be destroyed with
@@ -33,7 +35,7 @@ public:
     // destroying the mpv_handle.
     // Never create multiple wrappers from the same raw mpv_handle; copy the
     // wrapper instead (that's what it's for).
-    static Handle FromRawHandle(mpv_handle *handle) {
+    static Handle FromRawHandle(mpv_handle* handle) {
         Handle h;
         h.sptr = QSharedPointer<container>(new container(handle));
         return h;
@@ -43,30 +45,23 @@ public:
     operator mpv_handle*() const { return sptr ? (*sptr).mpv : nullptr; }
 };
 
-static inline QVariant node_to_variant(const mpv_node *node)
-{
+static inline QVariant node_to_variant(const mpv_node* node) {
     switch (node->format) {
-    case MPV_FORMAT_STRING:
-        return QVariant(QString::fromUtf8(node->u.string));
-    case MPV_FORMAT_FLAG:
-        return QVariant(static_cast<bool>(node->u.flag));
-    case MPV_FORMAT_INT64:
-        return QVariant(static_cast<qlonglong>(node->u.int64));
-    case MPV_FORMAT_DOUBLE:
-        return QVariant(node->u.double_);
+    case MPV_FORMAT_STRING: return QVariant(QString::fromUtf8(node->u.string));
+    case MPV_FORMAT_FLAG: return QVariant(static_cast<bool>(node->u.flag));
+    case MPV_FORMAT_INT64: return QVariant(static_cast<qlonglong>(node->u.int64));
+    case MPV_FORMAT_DOUBLE: return QVariant(node->u.double_);
     case MPV_FORMAT_NODE_ARRAY: {
-        mpv_node_list *list = node->u.list;
-        QVariantList qlist;
-        for (int n = 0; n < list->num; n++)
-            qlist.append(node_to_variant(&list->values[n]));
+        mpv_node_list* list = node->u.list;
+        QVariantList   qlist;
+        for (int n = 0; n < list->num; n++) qlist.append(node_to_variant(&list->values[n]));
         return QVariant(qlist);
     }
     case MPV_FORMAT_NODE_MAP: {
-        mpv_node_list *list = node->u.list;
-        QVariantMap qmap;
+        mpv_node_list* list = node->u.list;
+        QVariantMap    qmap;
         for (int n = 0; n < list->num; n++) {
-            qmap.insert(QString::fromUtf8(list->keys[n]),
-                        node_to_variant(&list->values[n]));
+            qmap.insert(QString::fromUtf8(list->keys[n]), node_to_variant(&list->values[n]));
         }
         return QVariant(qmap);
     }
@@ -76,40 +71,34 @@ static inline QVariant node_to_variant(const mpv_node *node)
 }
 
 struct node_builder {
-    explicit node_builder(const QVariant& v)
-        : node_() {
-        set(&node_, v);
-    }
-    ~node_builder() {
-        free_node(&node_);
-    }
-    mpv_node *node() { return &node_; }
+    explicit node_builder(const QVariant& v): node_() { set(&node_, v); }
+    ~node_builder() { free_node(&node_); }
+    mpv_node* node() { return &node_; }
+
 private:
     Q_DISABLE_COPY(node_builder)
     mpv_node node_;
 
-    mpv_node_list *create_list(mpv_node *dst, bool is_map, int num) {
+    mpv_node_list* create_list(mpv_node* dst, bool is_map, int num) {
         dst->format = is_map ? MPV_FORMAT_NODE_MAP : MPV_FORMAT_NODE_ARRAY;
         try {
-            mpv_node_list *list = new mpv_node_list();
-            dst->u.list = list;
-            list->values = new mpv_node[num]();
-            if (is_map)
-                list->keys = new char *[num]();
+            mpv_node_list* list = new mpv_node_list();
+            dst->u.list         = list;
+            list->values        = new mpv_node[num]();
+            if (is_map) list->keys = new char*[num]();
             return list;
-        }
-        catch (const std::bad_alloc &) {
+        } catch (const std::bad_alloc&) {
             free_node(dst);
             return nullptr;
         }
     }
-    char *dup_qstring(const QString &s) {
+    char* dup_qstring(const QString& s) {
         QByteArray b = s.toUtf8();
-        char *r = new char[b.size() + 1];
+        char*      r = new char[b.size() + 1];
         std::memcpy(r, b.data(), b.size() + 1);
         return r;
     }
-    bool test_type(const QVariant &v, QMetaType::Type t) {
+    bool test_type(const QVariant& v, QMetaType::Type t) {
         // The Qt docs say: "Although this function is declared as returning
         // "QVariant::Type(obsolete), the return value should be interpreted
         // as QMetaType::Type."
@@ -120,42 +109,35 @@ private:
         return static_cast<int>(v.type()) == static_cast<int>(t);
 #endif
     }
-    void set(mpv_node *dst, const QVariant &src) {
+    void set(mpv_node* dst, const QVariant& src) {
         if (test_type(src, QMetaType::QString)) {
-            dst->format = MPV_FORMAT_STRING;
+            dst->format   = MPV_FORMAT_STRING;
             dst->u.string = dup_qstring(src.toString());
-            if (!dst->u.string)
-                goto fail;
+            if (! dst->u.string) goto fail;
         } else if (test_type(src, QMetaType::Bool)) {
             dst->format = MPV_FORMAT_FLAG;
             dst->u.flag = src.toBool() ? 1 : 0;
-        } else if (test_type(src, QMetaType::Int) ||
-                   test_type(src, QMetaType::LongLong) ||
-                   test_type(src, QMetaType::UInt) ||
-                   test_type(src, QMetaType::ULongLong))
-        {
-            dst->format = MPV_FORMAT_INT64;
+        } else if (test_type(src, QMetaType::Int) || test_type(src, QMetaType::LongLong) ||
+                   test_type(src, QMetaType::UInt) || test_type(src, QMetaType::ULongLong)) {
+            dst->format  = MPV_FORMAT_INT64;
             dst->u.int64 = src.toLongLong();
         } else if (test_type(src, QMetaType::Double)) {
-            dst->format = MPV_FORMAT_DOUBLE;
+            dst->format    = MPV_FORMAT_DOUBLE;
             dst->u.double_ = src.toDouble();
         } else if (src.canConvert<QVariantList>()) {
-            QVariantList qlist = src.toList();
-            mpv_node_list *list = create_list(dst, false, qlist.size());
-            if (!list)
-                goto fail;
+            QVariantList   qlist = src.toList();
+            mpv_node_list* list  = create_list(dst, false, qlist.size());
+            if (! list) goto fail;
             list->num = qlist.size();
-            for (int n = 0; n < qlist.size(); n++)
-                set(&list->values[n], qlist[n]);
+            for (int n = 0; n < qlist.size(); n++) set(&list->values[n], qlist[n]);
         } else if (src.canConvert<QVariantMap>()) {
-            QVariantMap qmap = src.toMap();
-            mpv_node_list *list = create_list(dst, true, qmap.size());
-            if (!list)
-                goto fail;
+            QVariantMap    qmap = src.toMap();
+            mpv_node_list* list = create_list(dst, true, qmap.size());
+            if (! list) goto fail;
             list->num = qmap.size();
             for (int n = 0; n < qmap.size(); n++) {
                 list->keys[n] = dup_qstring(qmap.keys()[n]);
-                if (!list->keys[n]) {
+                if (! list->keys[n]) {
                     free_node(dst);
                     goto fail;
                 }
@@ -168,20 +150,16 @@ private:
     fail:
         dst->format = MPV_FORMAT_NONE;
     }
-    void free_node(mpv_node *dst) {
+    void free_node(mpv_node* dst) {
         switch (dst->format) {
-        case MPV_FORMAT_STRING:
-            delete[] dst->u.string;
-            break;
+        case MPV_FORMAT_STRING: delete[] dst->u.string; break;
         case MPV_FORMAT_NODE_ARRAY:
         case MPV_FORMAT_NODE_MAP: {
-            mpv_node_list *list = dst->u.list;
+            mpv_node_list* list = dst->u.list;
             if (list) {
                 for (int n = 0; n < list->num; n++) {
-                    if (list->keys)
-                        delete[] list->keys[n];
-                    if (list->values)
-                        free_node(&list->values[n]);
+                    if (list->keys) delete[] list->keys[n];
+                    if (list->values) free_node(&list->values[n]);
                 }
                 delete[] list->keys;
                 delete[] list->values;
@@ -189,7 +167,7 @@ private:
             delete list;
             break;
         }
-        default: ;
+        default:;
         }
         dst->format = MPV_FORMAT_NONE;
     }
@@ -199,8 +177,8 @@ private:
  * RAII wrapper that calls mpv_free_node_contents() on the pointer.
  */
 struct node_autofree {
-    mpv_node *ptr;
-    explicit node_autofree(mpv_node *a_ptr) : ptr(a_ptr) {}
+    mpv_node* ptr;
+    explicit node_autofree(mpv_node* a_ptr): ptr(a_ptr) {}
     ~node_autofree() { mpv_free_node_contents(ptr); }
 };
 
@@ -212,11 +190,9 @@ struct node_autofree {
  *
  * @param name the property name
  */
-static inline QVariant get_property_variant(mpv_handle *ctx, const QString &name)
-{
+static inline QVariant get_property_variant(mpv_handle* ctx, const QString& name) {
     mpv_node node;
-    if (mpv_get_property(ctx, name.toUtf8().data(), MPV_FORMAT_NODE, &node) < 0)
-        return QVariant();
+    if (mpv_get_property(ctx, name.toUtf8().data(), MPV_FORMAT_NODE, &node) < 0) return QVariant();
     node_autofree f(&node);
     return node_to_variant(&node);
 }
@@ -226,9 +202,7 @@ static inline QVariant get_property_variant(mpv_handle *ctx, const QString &name
 
  * @deprecated use set_property() instead
  */
-static inline int set_property_variant(mpv_handle *ctx, const QString &name,
-                                       const QVariant &v)
-{
+static inline int set_property_variant(mpv_handle* ctx, const QString& name, const QVariant& v) {
     node_builder node(v);
     return mpv_set_property(ctx, name.toUtf8().data(), MPV_FORMAT_NODE, node.node());
 }
@@ -238,9 +212,7 @@ static inline int set_property_variant(mpv_handle *ctx, const QString &name,
  *
  * @deprecated use set_property() instead
  */
-static inline int set_option_variant(mpv_handle *ctx, const QString &name,
-                                     const QVariant &v)
-{
+static inline int set_option_variant(mpv_handle* ctx, const QString& name, const QVariant& v) {
     node_builder node(v);
     return mpv_set_option(ctx, name.toUtf8().data(), MPV_FORMAT_NODE, node.node());
 }
@@ -251,12 +223,10 @@ static inline int set_option_variant(mpv_handle *ctx, const QString &name,
  *
  * @deprecated use command() instead
  */
-static inline QVariant command_variant(mpv_handle *ctx, const QVariant &args)
-{
+static inline QVariant command_variant(mpv_handle* ctx, const QVariant& args) {
     node_builder node(args);
-    mpv_node res;
-    if (mpv_command_node(ctx, node.node(), &res) < 0)
-        return QVariant();
+    mpv_node     res;
+    if (mpv_command_node(ctx, node.node(), &res) < 0) return QVariant();
     node_autofree f(&res);
     return node_to_variant(&res);
 }
@@ -268,15 +238,14 @@ static inline QVariant command_variant(mpv_handle *ctx, const QVariant &args)
  * You can use get_error() or is_error() to extract the error status from a
  * QVariant value.
  */
-struct ErrorReturn
-{
+struct ErrorReturn {
     /**
      * enum mpv_error value (or a value outside of it if ABI was extended)
      */
     int error;
 
-    ErrorReturn() : error(0) {}
-    explicit ErrorReturn(int err) : error(err) {}
+    ErrorReturn(): error(0) {}
+    explicit ErrorReturn(int err): error(err) {}
 };
 
 /**
@@ -285,20 +254,15 @@ struct ErrorReturn
  *
  * @return error code (<0) or success (>=0)
  */
-static inline int get_error(const QVariant &v)
-{
-    if (!v.canConvert<ErrorReturn>())
-        return 0;
+static inline int get_error(const QVariant& v) {
+    if (! v.canConvert<ErrorReturn>()) return 0;
     return v.value<ErrorReturn>().error;
 }
 
 /**
  * Return whether the QVariant carries a mpv error code.
  */
-static inline bool is_error(const QVariant &v)
-{
-    return get_error(v) < 0;
-}
+static inline bool is_error(const QVariant& v) { return get_error(v) < 0; }
 
 /**
  * Return the given property as mpv_node converted to QVariant, or QVariant()
@@ -307,12 +271,10 @@ static inline bool is_error(const QVariant &v)
  * @param name the property name
  * @return the property value, or an ErrorReturn with the error code
  */
-static inline QVariant get_property(mpv_handle *ctx, const QString &name)
-{
+static inline QVariant get_property(mpv_handle* ctx, const QString& name) {
     mpv_node node;
-    int err = mpv_get_property(ctx, name.toUtf8().data(), MPV_FORMAT_NODE, &node);
-    if (err < 0)
-        return QVariant::fromValue(ErrorReturn(err));
+    int      err = mpv_get_property(ctx, name.toUtf8().data(), MPV_FORMAT_NODE, &node);
+    if (err < 0) return QVariant::fromValue(ErrorReturn(err));
     node_autofree f(&node);
     return node_to_variant(&node);
 }
@@ -322,9 +284,7 @@ static inline QVariant get_property(mpv_handle *ctx, const QString &name)
  *
  * @return mpv error code (<0 on error, >= 0 on success)
  */
-static inline int set_property(mpv_handle *ctx, const QString &name,
-                                       const QVariant &v)
-{
+static inline int set_property(mpv_handle* ctx, const QString& name, const QVariant& v) {
     node_builder node(v);
     return mpv_set_property(ctx, name.toUtf8().data(), MPV_FORMAT_NODE, node.node());
 }
@@ -335,19 +295,17 @@ static inline int set_property(mpv_handle *ctx, const QString &name,
  * @param args command arguments, with args[0] being the command name as string
  * @return the property value, or an ErrorReturn with the error code
  */
-static inline QVariant command(mpv_handle *ctx, const QVariant &args)
-{
+static inline QVariant command(mpv_handle* ctx, const QVariant& args) {
     node_builder node(args);
-    mpv_node res;
-    int err = mpv_command_node(ctx, node.node(), &res);
-    if (err < 0)
-        return QVariant::fromValue(ErrorReturn(err));
+    mpv_node     res;
+    int          err = mpv_command_node(ctx, node.node(), &res);
+    if (err < 0) return QVariant::fromValue(ErrorReturn(err));
     node_autofree f(&res);
     return node_to_variant(&res);
 }
 
-}
-}
+} // namespace qt
+} // namespace mpv
 
 Q_DECLARE_METATYPE(mpv::qt::ErrorReturn)
 

--- a/src/backend_mpv/standalone_viewer/qmlviewer.cpp
+++ b/src/backend_mpv/standalone_viewer/qmlviewer.cpp
@@ -7,22 +7,21 @@
 #include <string>
 #include "MpvBackend.hpp"
 
-int main(int argc, char **argv)
-{
-	if(argc != 2) {
-		std::cerr << "usage: "+ std::string(argv[0]) +" <video file>\n";
-		return 1;
-	}
-	QCoreApplication::setAttribute(Qt::AA_DisableHighDpiScaling);
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        std::cerr << "usage: " + std::string(argv[0]) + " <video file>\n";
+        return 1;
+    }
+    QCoreApplication::setAttribute(Qt::AA_DisableHighDpiScaling);
     QGuiApplication app(argc, argv);
-	qmlRegisterType<mpv::MpvObject>("mpvtest", 1, 0, "MpvObject");
-	setlocale(LC_NUMERIC, "C");
+    qmlRegisterType<mpv::MpvObject>("mpvtest", 1, 0, "MpvObject");
+    setlocale(LC_NUMERIC, "C");
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
     view.setSource(QUrl("qrc:///qml/main.qml"));
     view.show();
-	QObject *obj = view.rootObject();
-	mpv::MpvObject* mpv = obj->findChild<mpv::MpvObject *>();
-	mpv->setSource(QUrl::fromLocalFile(argv[1]));
+    QObject*        obj = view.rootObject();
+    mpv::MpvObject* mpv = obj->findChild<mpv::MpvObject*>();
+    mpv->setSource(QUrl::fromLocalFile(argv[1]));
     return app.exec();
 }


### PR DESCRIPTION
Apply clang-format to resolve all -Wclang-format-violations errors in:
- src/FileHelper.cpp, src/FileHelper.hpp
- src/MouseGrabber.cpp, src/MouseGrabber.hpp
- src/TTYSwitchMonitor.cpp, src/TTYSwitchMonitor.hpp
- src/backend_mpv/MpvBackend.cpp
- src/backend_mpv/qthelper.hpp
- src/backend_mpv/standalone_viewer/qmlviewer.cpp
