### PR TITLE
Add testing framework and CI/CD pipelines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,98 @@
+name: Build
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  # ── Arch Linux (primary target distribution) ──────────────────────────────
+  build-arch:
+    name: Full build — Arch Linux
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+
+    steps:
+      - name: Install git (needed for checkout action inside container)
+        run: pacman -Sy --noconfirm git
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          pacman -Su --noconfirm
+          pacman -S --noconfirm \
+            base-devel \
+            cmake \
+            ninja \
+            extra-cmake-modules \
+            plasma-framework \
+            qt6-declarative \
+            qt6-websockets \
+            qt6-webchannel \
+            vulkan-headers \
+            mpv \
+            lz4
+
+      - name: Configure
+        run: |
+          cmake -B build -S . \
+            -DCMAKE_BUILD_TYPE=Release \
+            -G Ninja
+
+      - name: Build
+        run: cmake --build build -j$(nproc)
+
+  # ── Fedora (secondary target distribution) ───────────────────────────────
+  build-fedora:
+    name: Full build — Fedora
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
+
+    steps:
+      - name: Install git
+        run: dnf install -y git
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Enable RPM Fusion (needed for mpv)
+        run: |
+          dnf install -y \
+            "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm" \
+            "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm"
+          dnf swap -y ffmpeg-free ffmpeg --allowerasing
+          dnf install -y ffmpeg-devel --allowerasing
+
+      - name: Install build dependencies
+        run: |
+          dnf install -y \
+            cmake \
+            ninja-build \
+            extra-cmake-modules \
+            vulkan-headers \
+            plasma-workspace-devel \
+            kf6-plasma-devel \
+            kf6-kcoreaddons-devel \
+            kf6-kpackage-devel \
+            lz4-devel \
+            mpv-libs-devel \
+            qt6-qtbase-private-devel \
+            libplasma-devel \
+            qt6-qtwebchannel-devel \
+            qt6-qtwebsockets-devel \
+            qt6-qtdeclarative-devel
+
+      - name: Configure
+        run: |
+          cmake -B build -S . \
+            -DCMAKE_BUILD_TYPE=Release \
+            -G Ninja
+
+      - name: Build
+        run: cmake --build build -j$(nproc)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: Lint
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  clang-format:
+    name: clang-format check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format
+
+      - name: Check C++ formatting
+        # --dry-run prints differences; --Werror turns any difference into a
+        # non-zero exit code so the job fails on style violations.
+        run: |
+          find src -name "*.cpp" -o -name "*.hpp" | \
+            xargs clang-format --dry-run --Werror

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  unit-tests:
+    name: FileHelper unit tests (Qt6 only)
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+        # No submodules needed — tests only depend on Qt6 Core + Test
+
+      - name: Install Qt6
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qt6-base-dev cmake ninja-build
+
+      - name: Configure (standalone test build)
+        # Build the tests/ directory directly — avoids the KDE/Plasma/mpv/Vulkan
+        # dependencies that the full plugin requires.
+        run: |
+          cmake -B build/tests -S tests \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -G Ninja
+
+      - name: Build
+        run: cmake --build build/tests
+
+      - name: Run tests
+        run: ctest --test-dir build/tests --output-on-failure -V

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,3 +73,9 @@ set(QMLPLUGIN_URI "com.github.catsout.wallpaperEngineKde")
 string(REPLACE "." "/" QMLPLUGIN_INSTALL_URI ${QMLPLUGIN_URI})
 
 add_subdirectory(src)
+
+option(BUILD_TESTS "Build unit tests (requires only Qt6 Core+Test)" OFF)
+if(BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Can be built standalone:  cmake -B build/tests -S tests
+# Or included from root with: -DBUILD_TESTS=ON
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    cmake_minimum_required(VERSION 3.16)
+    project(WallpaperEngineKdeTests CXX)
+    set(CMAKE_CXX_STANDARD 20)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_EXTENSIONS OFF)
+    enable_testing()
+    set(WEKDE_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../src")
+else()
+    set(WEKDE_SRC_DIR "${CMAKE_SOURCE_DIR}/src")
+endif()
+
+find_package(Qt6 REQUIRED COMPONENTS Core Test)
+set(CMAKE_AUTOMOC ON)
+
+# ── FileHelper unit tests ──────────────────────────────────────────────────────
+add_executable(tst_filehelper
+    tst_filehelper.cpp
+    ${WEKDE_SRC_DIR}/FileHelper.cpp
+)
+target_include_directories(tst_filehelper PRIVATE ${WEKDE_SRC_DIR})
+target_link_libraries(tst_filehelper PRIVATE Qt6::Core Qt6::Test)
+add_test(NAME tst_filehelper COMMAND tst_filehelper -v2)

--- a/tests/tst_filehelper.cpp
+++ b/tests/tst_filehelper.cpp
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Unit tests for wekde::FileHelper
+//
+// getDirSize behaviour note (depth > 0):
+//   The loop at FileHelper.cpp:62-76 accumulates into totalSize but is then
+//   immediately overwritten by `totalSize = calcSize(path, 1)` at line 98.
+//   That loop is therefore dead code; only calcSize() determines the result.
+//   calcSize starts at currentDepth=1 and recurses while currentDepth < depth,
+//   so depth=N counts files up to N directory levels from the root.
+
+#include <QtTest>
+#include <QDir>
+#include <QFile>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+#include <QTemporaryFile>
+#include <QVariantList>
+#include <QVariantMap>
+
+#include "FileHelper.hpp"
+
+using namespace wekde;
+
+class TestFileHelper : public QObject {
+    Q_OBJECT
+
+private:
+    QTemporaryDir m_tmp;
+
+    // Write `size` bytes to `filePath`; returns true on success.
+    static bool writeBytes(const QString& filePath, int size, char fill = 'x') {
+        QFile f(filePath);
+        if (!f.open(QIODevice::WriteOnly)) return false;
+        f.write(QByteArray(size, fill));
+        return true;
+    }
+
+private slots:
+    // ── test-suite setup / teardown ───────────────────────────────────────────
+    void initTestCase() {
+        // Redirect QStandardPaths to a safe test location so tests never
+        // touch the real user config directory.
+        QStandardPaths::setTestModeEnabled(true);
+        QVERIFY2(m_tmp.isValid(), "Could not create temporary directory for tests");
+    }
+
+    void cleanupTestCase() {
+        QString testCfg =
+            QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) + "/wekde";
+        QDir(testCfg).removeRecursively();
+        QStandardPaths::setTestModeEnabled(false);
+    }
+
+    // ── readFile ──────────────────────────────────────────────────────────────
+    void readFile_existingFile() {
+        QTemporaryFile f(m_tmp.filePath("read_XXXXXX"));
+        f.setAutoRemove(false);
+        QVERIFY(f.open());
+        f.write("hello world");
+        f.close();
+
+        FileHelper helper;
+        QCOMPARE(helper.readFile(f.fileName()), QByteArray("hello world"));
+    }
+
+    void readFile_nonExistentFile() {
+        FileHelper helper;
+        QByteArray result = helper.readFile("/tmp/wekde_test_nonexistent_file_xyz.txt");
+        QVERIFY(result.isEmpty());
+    }
+
+    void readFile_emptyFile() {
+        QTemporaryFile f(m_tmp.filePath("empty_XXXXXX"));
+        QVERIFY(f.open());
+        f.close(); // zero bytes
+
+        FileHelper helper;
+        QVERIFY(helper.readFile(f.fileName()).isEmpty());
+    }
+
+    void readFile_binaryContent() {
+        QByteArray binary;
+        for (int i = 0; i < 256; ++i) binary.append(static_cast<char>(i));
+
+        QTemporaryFile f(m_tmp.filePath("bin_XXXXXX"));
+        f.setAutoRemove(false);
+        QVERIFY(f.open());
+        f.write(binary);
+        f.close();
+
+        FileHelper helper;
+        QCOMPARE(helper.readFile(f.fileName()), binary);
+    }
+
+    // ── getDirSize ────────────────────────────────────────────────────────────
+    void getDirSize_nonExistentDir() {
+        FileHelper helper;
+        QCOMPARE(helper.getDirSize("/tmp/wekde_test_nonexistent_dir_xyz"), qint64(0));
+    }
+
+    void getDirSize_emptyDir() {
+        QTemporaryDir d;
+        FileHelper helper;
+        QCOMPARE(helper.getDirSize(d.path()), qint64(0));
+    }
+
+    void getDirSize_topLevelFiles_depth1() {
+        QTemporaryDir d;
+        QVERIFY(writeBytes(d.filePath("a.txt"), 100));
+        QVERIFY(writeBytes(d.filePath("b.txt"), 150));
+
+        FileHelper helper;
+        QCOMPARE(helper.getDirSize(d.path(), 1), qint64(250));
+    }
+
+    void getDirSize_depth1_ignoresSubdirFiles() {
+        QTemporaryDir d;
+        QVERIFY(writeBytes(d.filePath("root.txt"), 100));
+        QVERIFY(d.path().length() > 0);
+        QDir(d.path()).mkdir("sub");
+        QVERIFY(writeBytes(d.filePath("sub/sub.txt"), 200));
+
+        FileHelper helper;
+        // depth=1 → only root files counted
+        QCOMPARE(helper.getDirSize(d.path(), 1), qint64(100));
+    }
+
+    void getDirSize_depth2_includesOneLevel() {
+        QTemporaryDir d;
+        QVERIFY(writeBytes(d.filePath("root.txt"), 100));
+        QDir(d.path()).mkdir("sub");
+        QVERIFY(writeBytes(d.filePath("sub/sub.txt"), 200));
+        QDir(d.filePath("sub")).mkdir("subsub");
+        QVERIFY(writeBytes(d.filePath("sub/subsub/deep.txt"), 300));
+
+        FileHelper helper;
+        // depth=2 → root + immediate subdir, NOT sub/subsub
+        QCOMPARE(helper.getDirSize(d.path(), 2), qint64(300));
+    }
+
+    void getDirSize_depth3_includesTwoLevels() {
+        QTemporaryDir d;
+        QVERIFY(writeBytes(d.filePath("root.txt"), 100));
+        QDir(d.path()).mkdir("sub");
+        QVERIFY(writeBytes(d.filePath("sub/sub.txt"), 200));
+        QDir(d.filePath("sub")).mkdir("subsub");
+        QVERIFY(writeBytes(d.filePath("sub/subsub/deep.txt"), 300));
+
+        FileHelper helper;
+        // depth=3 (default) → root + sub + sub/subsub
+        QCOMPARE(helper.getDirSize(d.path(), 3), qint64(600));
+    }
+
+    void getDirSize_unlimitedDepth() {
+        QTemporaryDir d;
+        // Create a 4-level-deep file (beyond default depth=3)
+        QDir r(d.path());
+        QVERIFY(r.mkpath("a/b/c/d"));
+        QVERIFY(writeBytes(d.filePath("a/b/c/d/deep.txt"), 500));
+
+        FileHelper helper;
+        // depth=0 → unlimited; must find the file no matter how deep
+        QCOMPARE(helper.getDirSize(d.path(), 0), qint64(500));
+    }
+
+    // ── getFolderList ─────────────────────────────────────────────────────────
+    void getFolderList_nonExistentDirNoFallback() {
+        FileHelper helper;
+        QVariantMap result = helper.getFolderList("/tmp/wekde_test_nodir_xyz");
+        QVERIFY(result.isEmpty());
+    }
+
+    void getFolderList_existingDir_returnsItems() {
+        QTemporaryDir d;
+        QDir(d.path()).mkdir("wallA");
+        QDir(d.path()).mkdir("wallB");
+
+        FileHelper helper;
+        QVariantMap result = helper.getFolderList(d.path());
+        QVERIFY(!result.isEmpty());
+        QCOMPARE(result["folder"].toString(), d.path());
+
+        QVariantList items = result["items"].toList();
+        QCOMPARE(items.size(), 2);
+
+        // Each item must have "name" and numeric "mtime"
+        for (const QVariant& v : items) {
+            QVariantMap item = v.toMap();
+            QVERIFY(item.contains("name"));
+            QVERIFY(item.contains("mtime"));
+            QVERIFY(item["mtime"].toLongLong() > 0);
+        }
+    }
+
+    void getFolderList_fallbackUsedWhenPrimaryMissing() {
+        QTemporaryDir d;
+        QDir(d.path()).mkdir("fallback");
+
+        FileHelper helper;
+        QVariantMap opts;
+        opts["fallbacks"] = QStringList{d.filePath("fallback")};
+
+        QVariantMap result = helper.getFolderList("/tmp/wekde_test_nodir_xyz", opts);
+        QVERIFY(!result.isEmpty());
+        QCOMPARE(result["folder"].toString(), d.filePath("fallback"));
+    }
+
+    void getFolderList_firstValidFallbackChosen() {
+        QTemporaryDir d;
+        QDir(d.path()).mkdir("second");
+
+        FileHelper helper;
+        QVariantMap opts;
+        // first fallback does not exist; second does
+        opts["fallbacks"] =
+            QStringList{"/tmp/wekde_no_such_dir_1", d.filePath("second")};
+
+        QVariantMap result = helper.getFolderList("/tmp/wekde_no_such_dir_2", opts);
+        QVERIFY(!result.isEmpty());
+        QCOMPARE(result["folder"].toString(), d.filePath("second"));
+    }
+
+    void getFolderList_onlyDir_true_excludesFiles() {
+        QTemporaryDir d;
+        QDir(d.path()).mkdir("sub");
+        QVERIFY(writeBytes(d.filePath("file.txt"), 1));
+
+        FileHelper helper;
+        // Default: only_dir=true
+        QVariantMap result = helper.getFolderList(d.path());
+        QVariantList items = result["items"].toList();
+        QCOMPARE(items.size(), 1);
+        QCOMPARE(items[0].toMap()["name"].toString(), QString("sub"));
+    }
+
+    void getFolderList_onlyDir_false_includesFiles() {
+        QTemporaryDir d;
+        QDir(d.path()).mkdir("sub");
+        QVERIFY(writeBytes(d.filePath("file.txt"), 1));
+
+        FileHelper helper;
+        QVariantMap opts;
+        opts["only_dir"] = false;
+
+        QVariantMap result = helper.getFolderList(d.path(), opts);
+        QVariantList items = result["items"].toList();
+        QCOMPARE(items.size(), 2);
+    }
+
+    void getFolderList_emptyDir_returnsEmptyItems() {
+        QTemporaryDir d;
+        FileHelper helper;
+        QVariantMap result = helper.getFolderList(d.path());
+        QVERIFY(!result.isEmpty());
+        QVERIFY(result["items"].toList().isEmpty());
+    }
+
+    // ── wallpaper config round-trip ───────────────────────────────────────────
+    void config_readNonExistent_returnsEmpty() {
+        FileHelper helper;
+        QVERIFY(helper.readWallpaperConfig("__no_such_wallpaper__").isEmpty());
+    }
+
+    void config_writeAndRead_roundTrip() {
+        FileHelper helper;
+        const QString id = "test_roundtrip";
+
+        QVariantMap cfg;
+        cfg["volume"] = 75;
+        cfg["fps"]    = 30;
+        cfg["mute"]   = false;
+        helper.writeWallpaperConfig(id, cfg);
+
+        QVariantMap got = helper.readWallpaperConfig(id);
+        QCOMPARE(got["volume"].toInt(), 75);
+        QCOMPARE(got["fps"].toInt(), 30);
+        QCOMPARE(got["mute"].toBool(), false);
+
+        helper.resetWallpaperConfig(id);
+    }
+
+    void config_write_mergesPreviousValues() {
+        FileHelper helper;
+        const QString id = "test_merge";
+
+        helper.writeWallpaperConfig(id, {{"volume", 50}, {"fps", 60}});
+
+        // Partial update: only change volume
+        helper.writeWallpaperConfig(id, {{"volume", 80}});
+
+        QVariantMap got = helper.readWallpaperConfig(id);
+        QCOMPARE(got["volume"].toInt(), 80);
+        QCOMPARE(got["fps"].toInt(), 60); // unchanged
+
+        helper.resetWallpaperConfig(id);
+    }
+
+    void config_write_addsNewKey() {
+        FileHelper helper;
+        const QString id = "test_newkey";
+
+        helper.writeWallpaperConfig(id, {{"a", 1}});
+        helper.writeWallpaperConfig(id, {{"b", 2}});
+
+        QVariantMap got = helper.readWallpaperConfig(id);
+        QCOMPARE(got["a"].toInt(), 1);
+        QCOMPARE(got["b"].toInt(), 2);
+
+        helper.resetWallpaperConfig(id);
+    }
+
+    void config_reset_removesConfig() {
+        FileHelper helper;
+        const QString id = "test_reset";
+
+        helper.writeWallpaperConfig(id, {{"key", "value"}});
+        QVERIFY(!helper.readWallpaperConfig(id).isEmpty());
+
+        helper.resetWallpaperConfig(id);
+        QVERIFY(helper.readWallpaperConfig(id).isEmpty());
+    }
+
+    void config_reset_nonExistent_noError() {
+        FileHelper helper;
+        // Resetting a config that was never written must not crash or throw
+        helper.resetWallpaperConfig("__never_existed__");
+        QVERIFY(helper.readWallpaperConfig("__never_existed__").isEmpty());
+    }
+
+    void config_stringValues_preserved() {
+        FileHelper helper;
+        const QString id = "test_strings";
+
+        helper.writeWallpaperConfig(id, {{"name", "My Wallpaper"}, {"path", "/some/path"}});
+
+        QVariantMap got = helper.readWallpaperConfig(id);
+        QCOMPARE(got["name"].toString(), QString("My Wallpaper"));
+        QCOMPARE(got["path"].toString(), QString("/some/path"));
+
+        helper.resetWallpaperConfig(id);
+    }
+};
+
+QTEST_MAIN(TestFileHelper)
+#include "tst_filehelper.moc"


### PR DESCRIPTION
- tests/CMakeLists.txt: standalone-capable build (cmake -B build/tests -S tests) compiles FileHelper.cpp directly against Qt6 Core+Test only — no KDE/mpv/Vulkan deps
- tests/tst_filehelper.cpp: 20 unit tests covering all FileHelper public methods (readFile, getDirSize depth semantics, getFolderList with fallbacks/filters, wallpaper config round-trip / merge / reset)
- CMakeLists.txt: adds BUILD_TESTS option (OFF by default) for integrated builds
- .github/workflows/tests.yml: runs unit tests on ubuntu-22.04 on every push/PR
- .github/workflows/build.yml: full plugin build on Arch Linux and Fedora containers
- .github/workflows/lint.yml: clang-format --dry-run --Werror check on all src/ files