### PR TITLE
fix: force QML update() at target FPS to prevent scene stutter on Wayland

### DIFF
--- a/plugin/contents/ui/backend/Scene.qml
+++ b/plugin/contents/ui/backend/Scene.qml
@@ -191,6 +191,21 @@ Item{
         }
     }
 
+    // Force QML to call update() on the SceneViewer at the target FPS.
+    // The C++ engine renders frames into a shared texture via its own
+    // FrameTimer, but the QML render thread only copies that texture to
+    // the swapchain when the item is marked dirty. Without this timer,
+    // QML throttles updatePaintNode to ~11fps (90ms intervals) even when
+    // the engine runs at 30-60fps, causing visible stutter on Wayland.
+    // See: https://github.com/captsilver/wallpaper-engine-kde-plugin/issues/24
+    Timer {
+        id: renderForceTimer
+        interval: Math.max(1, Math.floor(1000 / Math.max(1, background.fps)))
+        repeat: true
+        running: background.ok
+        onTriggered: player.update()
+    }
+
     Component.onCompleted: {
         background.nowBackend = 'scene';
     }


### PR DESCRIPTION
## Problem

Scene wallpapers stutter (irregular frame pacing) on Wayland even when the C++ engine renders at a stable FPS.

## Root Cause

The C++ scene engine (`wallpaper::FrameTimer`) renders frames into a shared Vulkan texture at the configured FPS (default 30). However, the QML render thread only copies that texture to the swapchain when the `SceneViewer` item is marked dirty via `update()`.

Without an explicit timer driving `update()`, QML throttles `updatePaintNode` to ~90ms intervals (~11fps), regardless of the engine's actual render rate. This was confirmed via `WEKDE_TIME_DIAG=1`:

Engine C++ (stable 30fps):
```
DIAG t=123s frame=3600 avg=33.0ms max=33.1ms
```

QML property evaluation (throttled to 11fps):
```
PROPEVAL deltas: [90, 90, 90, 90, 90, 90, 90, 90, 90]
```

The engine delivers a frame every 33ms, but QML only picks it up every 90ms — so 2 out of every 3 rendered frames are dropped before reaching the swapchain.

## Fix

Add a QML `Timer` that calls `player.update()` at `1000/fps` ms intervals, aligned with the engine's `FrameTimer`:

```qml
Timer {
    id: renderForceTimer
    interval: Math.max(1, Math.floor(1000 / Math.max(1, background.fps)))
    repeat: true
    running: background.ok
    onTriggered: player.update()
}
```

This ensures every rendered frame is presented to the swapchain without delay.

## Testing

**Environment:** Nobara Linux 43, NVIDIA RTX 4070 Ti SUPER, Plasma 6.7.2 / Qt 6.10.3 / Wayland, 1080p@60Hz

**Before (no timer):** Visible micro-stutter on scene wallpapers. Engine at 30fps, QML at 11fps.
**After (with timer):** Smooth playback. Engine at 30fps, QML update() at 30fps.

The timer is:
- Gated on `background.ok` — respects pause states (battery, TTY switch, window pause)
- Dynamic interval — follows `background.fps` if the user changes it
- Guarded — `Math.max(1, ...)` handles fps=0 or negative edge cases

## Related

- Issue: #24 (scene stutter on Wayland with FIFO present mode)
- This PR addresses the QML-side throttling; the issue also covers the Vulkan present mode aspect (MAILBOX as workaround)
